### PR TITLE
rbnacl: fix byffer size type in randombytes_buf binding

### DIFF
--- a/lib/rbnacl/random.rb
+++ b/lib/rbnacl/random.rb
@@ -13,7 +13,7 @@ module RbNaCl
 
     sodium_function :c_random_bytes,
                     :randombytes_buf,
-                    %i[pointer ulong_long]
+                    %i[pointer size_t]
 
     # Returns a string of random bytes
     #


### PR DESCRIPTION
https://github.com/jedisct1/libsodium/blob/master/src/libsodium/include/sodium/randombytes.h#L35
defines `randombytes_buf` buffer size as `size_t`:

```c
void randombytes_buf(void * const buf, const size_t size);
```

but rbnacl defines it as `unsigned long long`:

```ruby
     sodium_function :c_random_bytes,
                     :randombytes_buf,
                     %i[pointer ulong_long]
```

This manifests as an error on 32-bit big-endian platforms because `size_t`
is 32-bit there and `unsigned long long` is 64-bit.

I've found it as a testsuite crash on powerpc32:

```
  #1  0x0fb93580 in abort () from /lib/libc.so.6
  #2  0x0f622da8 in sodium_misuse () at /dev/shm/portage/dev-libs/libsodium-1.0.16-r1/work/libsodium-1.0.16/src/libsodium/sodium/core.c:216
  #3  0x0f629d8c in randombytes_sysrandom_buf (buf=0x110a68f0, size=258618072)
      at /dev/shm/portage/dev-libs/libsodium-1.0.16-r1/work/libsodium-1.0.16/src/libsodium/randombytes/sysrandom/randombytes_sysrandom.c:337
  #4  0x0f621e3c in randombytes_buf (buf=<optimized out>, size=<optimized out>)
      at /dev/shm/portage/dev-libs/libsodium-1.0.16-r1/work/libsodium-1.0.16/src/libsodium/randombytes/randombytes.c:155
  #5  0x0f664d38 in ?? () from /usr/lib/libffi.so.6
  #6  0x0f663ee8 in ffi_call () from /usr/lib/libffi.so.6
  #7  0x0f6a3c98 in rbffi_CallFunction (argc=<optimized out>, argv=<optimized out>, function=0xf621df0 <randombytes_buf>, fnInfo=0x10e5f790) at Call.c:409
  #8  0x0f69eba0 in attached_method_invoke (cif=<optimized out>, mretval=0xfff929e0, parameters=<optimized out>, user_data=<optimized out>) at MethodHandle.c:65
```

Note how `randombytes_sysrandom_buf` accepts big `size=258618072`.
The fix is simple: use `:size_t` from ruby's ffi package instead.

This change makes all tests pass on powerpc32.

Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>