### PR TITLE
Add support for XChaCha20-Poly1305

### DIFF
--- a/lib/rbnacl.rb
+++ b/lib/rbnacl.rb
@@ -81,6 +81,7 @@ module RbNaCl
   # AEAD: ChaCha20-Poly1305
   require "rbnacl/aead/chacha20poly1305_legacy"
   require "rbnacl/aead/chacha20poly1305_ietf"
+  require "rbnacl/aead/xchacha20poly1305_ietf"
 
   #
   # Bind aliases used by the public API

--- a/lib/rbnacl/aead/xchacha20poly1305_ietf.rb
+++ b/lib/rbnacl/aead/xchacha20poly1305_ietf.rb
@@ -1,0 +1,44 @@
+# encoding: binary
+# frozen_string_literal: true
+
+module RbNaCl
+  module AEAD
+    # This class contains wrappers for the IETF implementation of
+    # Authenticated Encryption with Additional Data using ChaCha20-Poly1305
+    class XChaCha20Poly1305IETF < RbNaCl::AEAD::Base
+      extend Sodium
+      if Sodium::Version.supported_version?("1.0.12")
+        sodium_type :aead
+        sodium_primitive :xchacha20poly1305_ietf
+
+        sodium_constant :KEYBYTES
+        sodium_constant :NPUBBYTES
+        sodium_constant :ABYTES
+
+        sodium_function :aead_xchacha20poly1305_ietf_encrypt,
+                        :crypto_aead_xchacha20poly1305_ietf_encrypt,
+                        %i[pointer pointer pointer ulong_long pointer ulong_long pointer pointer pointer]
+
+        sodium_function :aead_xchacha20poly1305_ietf_decrypt,
+                        :crypto_aead_xchacha20poly1305_ietf_decrypt,
+                        %i[pointer pointer pointer pointer ulong_long pointer ulong_long pointer pointer]
+
+        private
+
+        def do_encrypt(ciphertext, ciphertext_len, nonce, message, additional_data)
+          self.class.aead_xchacha20poly1305_ietf_encrypt(ciphertext, ciphertext_len,
+                                                         message, data_len(message),
+                                                         additional_data, data_len(additional_data),
+                                                         nil, nonce, @key)
+        end
+
+        def do_decrypt(message, message_len, nonce, ciphertext, additional_data)
+          self.class.aead_xchacha20poly1305_ietf_decrypt(message, message_len, nil,
+                                                         ciphertext, data_len(ciphertext),
+                                                         additional_data, data_len(additional_data),
+                                                         nonce, @key)
+        end
+      end
+    end
+  end
+end

--- a/lib/rbnacl/test_vectors.rb
+++ b/lib/rbnacl/test_vectors.rb
@@ -221,6 +221,25 @@ module RbNaCl
                                                 "3dbea45e8ca9671282fafb69da92728b1a71de0a9e060b2905d6a5b67ecd3b36" \
                                                 "92ddbd7f2d778b8c9803aee328091b58fab324e4fad675945585808b4831d7bc" \
                                                 "3ff4def08e4b7a9de576d26586cec64b61161ae10b594f09e26a7e902ecbd060" \
-                                                "0691"
+                                                "0691",
+
+    # Jank AEAD XChaCha20-Poly1305 test vectors
+    # Unfortunately, I couldn't find any public variants of these, so I used:
+    # https://github.com/jedisct1/libsodium/blob/1.0.16/test/default/aead_xchacha20poly1305.c
+    # Doubly unfortunately, that doesn't even have a ciphertext vector. I
+    # generated one using crypto_aead_xchacha20poly1305_ietf_encrypt on
+    # libsodium 1.0.16
+    aead_xchacha20poly1305_ietf_key:            "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+    aead_xchacha20poly1305_ietf_message:        "4c616469657320616e642047656e746c656d656e206f662074686520636c6173" \
+                                                "73206f66202739393a204966204920636f756c64206f6666657220796f75206f" \
+                                                "6e6c79206f6e652074697020666f7220746865206675747572652c2073756e73" \
+                                                "637265656e20776f756c642062652069742e",
+    aead_xchacha20poly1305_ietf_nonce:          "07000000404142434445464748494a4b0000000000000000",
+    aead_xchacha20poly1305_ietf_ad:             "50515253c0c1c2c3c4c5c6c7",
+    aead_xchacha20poly1305_ietf_ciphertext:     "453c0693a7407f04ff4c56aedb17a3c0a1afff01174930fc22287c33dbcf0ac8" \
+                                                "b89ad929530a1bb3ab5e69f24c7f6070c8f840c9abb4f69fbfc8a7ff5126faee" \
+                                                "bbb55805ee9c1cf2ce5a57263287aec5780f04ec324c3514122cfc3231fc1a8b" \
+                                                "718a62863730a2702bb76366116bed09e0fd5c6d84b6b0c1abaf249d5dd0f7f5" \
+                                                "a7ea"
   }.freeze
 end

--- a/spec/rbnacl/aead/xchacha20poly1305_ietf_spec.rb
+++ b/spec/rbnacl/aead/xchacha20poly1305_ietf_spec.rb
@@ -1,0 +1,14 @@
+# encoding: binary
+# frozen_string_literal: true
+
+RSpec.describe RbNaCl::AEAD::XChaCha20Poly1305IETF do
+  if RbNaCl::Sodium::Version.supported_version?("1.0.12")
+    include_examples "aead" do
+      let(:key)        { vector :aead_xchacha20poly1305_ietf_key }
+      let(:message)    { vector :aead_xchacha20poly1305_ietf_message }
+      let(:nonce)      { vector :aead_xchacha20poly1305_ietf_nonce }
+      let(:ad)         { vector :aead_xchacha20poly1305_ietf_ad }
+      let(:ciphertext) { vector :aead_xchacha20poly1305_ietf_ciphertext }
+    end
+  end
+end


### PR DESCRIPTION
Pretty self explanatory. This cipher is explicitly required by some things (i.e. [paseto]( https://github.com/paragonie/paseto/blob/master/docs/01-Protocol-Versions/Version2.md#encrypt)), so it'd be nice if we could use it directly.

See mguymon/paseto.rb#1 for a working example.