### PR TITLE
Support for Heroku

### DIFF
--- a/lib/rbnacl/init.rb
+++ b/lib/rbnacl/init.rb
@@ -5,7 +5,7 @@ module RbNaCl
   # Defines the libsodium init function
   module Init
     extend FFI::Library
-    ffi_lib "sodium"
+    ffi_lib ["sodium", "libsodium.so.18", "libsodium.so.23"]
 
     attach_function :sodium_init, [], :int
   end

--- a/lib/rbnacl/sodium.rb
+++ b/lib/rbnacl/sodium.rb
@@ -8,7 +8,7 @@ module RbNaCl
   module Sodium
     def self.extended(klass)
       klass.extend FFI::Library
-      klass.ffi_lib "sodium"
+      klass.ffi_lib ["sodium", "libsodium.so.18", "libsodium.so.23"]
     end
 
     def sodium_type(type = nil)


### PR DESCRIPTION
Hi, this PR allows rbnacl to work with Heroku out-of-the-box (since Heroku is a pretty popular platform for Ruby developers). FFI allows you to specify [alternate file names](https://github.com/ffi/ffi/wiki/Loading-Libraries), so it shouldn't cause any issues for other platforms.

Tested on Mac, the heroku-16 stack, and the heroku-18 stack.