### PR TITLE
v7.0.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## [7.0.0] (2019-05-23)
+
+- Drop support for Ruby 2.2 ([#194])
+
 ## [6.0.1] (2019-01-27)
 
 - Add fallback `sodium_constants` for Argon2 ([#189])
@@ -101,6 +105,8 @@
 
 - Initial release
 
+[7.0.0]: https://github.com/crypto-rb/rbnacl/pull/195
+[#194]: https://github.com/crypto-rb/rbnacl/pull/194
 [6.0.1]: https://github.com/crypto-rb/rbnacl/pull/191
 [#189]: https://github.com/crypto-rb/rbnacl/pull/189
 [#186]: https://github.com/crypto-rb/rbnacl/pull/186

--- a/lib/rbnacl/version.rb
+++ b/lib/rbnacl/version.rb
@@ -4,5 +4,5 @@
 # NaCl/libsodium for Ruby
 module RbNaCl
   # The library's version
-  VERSION = "6.0.1"
+  VERSION = "7.0.0"
 end


### PR DESCRIPTION
- Drop support for Ruby 2.2 (#194)