### PR TITLE
signatures: Cleanups for attached signature API

### DIFF
--- a/lib/rbnacl/signatures/ed25519/signing_key.rb
+++ b/lib/rbnacl/signatures/ed25519/signing_key.rb
@@ -73,25 +73,18 @@ module RbNaCl
         #
         # @return [String] Signature as bytes
         def sign(message)
-          buffer = Util.prepend_zeros(signature_bytes, message)
-          buffer_len = Util.zeros(FFI::Type::LONG_LONG.size)
-
-          self.class.sign_ed25519(buffer, buffer_len, message, message.bytesize, @signing_key)
-
-          buffer[0, signature_bytes]
+          sign_attached(message)[0, signature_bytes]
         end
 
-        # Sign a message using this key
+        # Sign a message using this key, attaching the signature to the message
         #
         # @param message [String] Message to be signed by this key
         #
         # @return [String] Signature and the message as bytes
-        def sign_full(message)
+        def sign_attached(message)
           buffer = Util.prepend_zeros(signature_bytes, message)
           buffer_len = Util.zeros(FFI::Type::LONG_LONG.size)
-
           self.class.sign_ed25519(buffer, buffer_len, message, message.bytesize, @signing_key)
-
           buffer
         end
 

--- a/lib/rbnacl/signatures/ed25519/verify_key.rb
+++ b/lib/rbnacl/signatures/ed25519/verify_key.rb
@@ -47,15 +47,7 @@ module RbNaCl
         def verify(signature, message)
           signature = signature.to_str
           Util.check_length(signature, signature_bytes, "signature")
-
-          sig_and_msg = signature + message
-          buffer = Util.zeros(sig_and_msg.bytesize)
-          buffer_len = Util.zeros(FFI::Type::LONG_LONG.size)
-
-          success = self.class.sign_ed25519_open(buffer, buffer_len, sig_and_msg, sig_and_msg.bytesize, @key)
-          raise(BadSignatureError, "signature was forged/corrupt") unless success
-
-          true
+          verify_attached(signature + message)
         end
 
         # Verify a signature for a given signed message
@@ -67,9 +59,8 @@ module RbNaCl
         # @raise [BadSignatureError] if the signature check fails
         #
         # @return [Boolean] was the signature authentic?
-        def verify_full(signed_message)
+        def verify_attached(signed_message)
           raise LengthError, "Signed message can not be nil" if signed_message.nil?
-
           raise LengthError, "Signed message can not be shorter than a signature" if signed_message.bytesize <= signature_bytes
 
           buffer = Util.zeros(signed_message.bytesize)

--- a/spec/rbnacl/signatures/ed25519/signing_key_spec.rb
+++ b/spec/rbnacl/signatures/ed25519/signing_key_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe RbNaCl::SigningKey do
   end
 
   it "signs messages, full version" do
-    expect(subject.sign_full(message)[0, RbNaCl::SigningKey.signature_bytes]).to eq signature
-    expect(subject.sign_full(message)[RbNaCl::SigningKey.signature_bytes, message.length]).to eq message
+    expect(subject.sign_attached(message)[0, RbNaCl::SigningKey.signature_bytes]).to eq signature
+    expect(subject.sign_attached(message)[RbNaCl::SigningKey.signature_bytes, message.length]).to eq message
   end
 
   it "serializes to bytes" do

--- a/spec/rbnacl/signatures/ed25519/verify_key_spec.rb
+++ b/spec/rbnacl/signatures/ed25519/verify_key_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe RbNaCl::VerifyKey do
   end
 
   it "verifies correct signatures, full version" do
-    expect(subject.verify_full(signature + message)).to eq true
+    expect(subject.verify_attached(signature + message)).to eq true
   end
 
   it "raises when asked to verify a bad signature" do
@@ -29,7 +29,7 @@ RSpec.describe RbNaCl::VerifyKey do
   end
 
   it "raises when asked to verify a bad signature, full version" do
-    expect { subject.verify_full(bad_signature + message) }.to raise_exception RbNaCl::BadSignatureError
+    expect { subject.verify_attached(bad_signature + message) }.to raise_exception RbNaCl::BadSignatureError
   end
 
   it "raises when asked to verify a short signature" do
@@ -37,11 +37,11 @@ RSpec.describe RbNaCl::VerifyKey do
   end
 
   it "raises when asked to verify a nil signed message" do
-    expect { subject.verify_full(nil) }.to raise_exception RbNaCl::LengthError
+    expect { subject.verify_attached(nil) }.to raise_exception RbNaCl::LengthError
   end
 
   it "raises when asked to verify too short signed message" do
-    expect { subject.verify_full(signature) }.to raise_exception RbNaCl::LengthError
+    expect { subject.verify_attached(signature) }.to raise_exception RbNaCl::LengthError
   end
 
   it "serializes to bytes" do


### PR DESCRIPTION
- Renames methods to `sign_attached` and `verify_attached`
- Implements the detached API in terms of the attached API